### PR TITLE
Cross-pools communication

### DIFF
--- a/exmples/collectors_chain/README.md
+++ b/exmples/collectors_chain/README.md
@@ -1,4 +1,4 @@
-# Pool Chain Processing - Example
+# Pool Chain Processing (with collectors) - Example
 
 This example demonstrates how to chain multiple worker pools using [go-pkgz/pool](https://github.com/go-pkgz/pool) package to create a concurrent processing pipeline. It shows how to transform data through multiple processing stages while maintaining type safety and proper coordination between pools.
 

--- a/exmples/collectors_chain/go.mod
+++ b/exmples/collectors_chain/go.mod
@@ -1,0 +1,9 @@
+module examples/collectors_chain
+
+go 1.24
+
+require github.com/go-pkgz/pool v0.5.0
+
+require golang.org/x/sync v0.11.0 // indirect
+
+replace github.com/go-pkgz/pool => ../..

--- a/exmples/collectors_chain/go.sum
+++ b/exmples/collectors_chain/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-pkgz/pool v0.5.0 h1:fP0WpEGMAcFEBQ7l7aAZsh7RBkzx34FVgufJoVvDTYY=
+github.com/go-pkgz/pool v0.5.0/go.mod h1:e1qn5EYmXshPcOk2buL2ZC20w7RTAWUgbug+L2SyH7I=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/exmples/direct_chain/README.md
+++ b/exmples/direct_chain/README.md
@@ -1,0 +1,104 @@
+# Pool Chain Processing (direct) - Example
+
+This example demonstrates how to chain multiple worker pools using [go-pkgz/pool](https://github.com/go-pkgz/pool) package to create a concurrent processing pipeline. Pools directly submit data to the next stage, with a collector only at the final stage to gather results.
+
+## Key Concepts
+
+1. Pool Chaining:
+   - Pools directly reference and send to the next pool
+   - Single collector at the end of chain
+   - Each stage processes independently
+   - Type-safe data transformation between stages
+
+2. Data Flow:
+   - Input strings -> count 'a's -> multiply by 10 -> square
+   - Each stage has its own worker pool
+   - Final collector gathers results
+   - Processing time tracked at each stage
+
+## Implementation Details
+
+The example shows three key patterns:
+
+1. Pool Declaration and Cross-References:
+   ```go
+   var pCounter *pool.WorkerGroup[stringData]
+   var pMulti *pool.WorkerGroup[countData]
+   var pSquares *pool.WorkerGroup[multipliedData]
+   collector := pool.NewCollector[finalData](ctx, 10)
+   ```
+
+2. Direct Pool Submission:
+   ```go
+   pCounter = pool.New[stringData](2, pool.WorkerFunc[stringData](
+       func(_ context.Context, d stringData) error {
+           count := strings.Count(d.data, "a")
+           if count > 2 {
+               pMulti.Send(countData{...}) // direct submission to next pool, thread safe version of Submit
+           }
+           return nil
+       }))
+   ```
+
+3. Pipeline Coordination:
+   ```go
+   go func() {
+       pCounter.Wait(ctx)  // wait for first pool
+       pMulti.Close(ctx)   // close second pool
+       pSquares.Close(ctx) // close final pool
+       collector.Close()   // close collector
+   }()
+   ```
+
+## Data Flow Types
+
+```go
+stringData {          countData {          multipliedData {        finalData {
+    idx  int             idx   int            idx   int              idx    int
+    data string          count int            value int              result int
+    ts   time.Time       ts    time.Time      ts    time.Time
+}                     }                     }                      }
+```
+
+## Features
+
+- Batch processing (size=3) in each pool
+- Filtering capabilities (count > 2)
+- Processing time tracking
+- Independent worker counts per stage
+- Built-in metrics collection
+- Simulated processing delays
+
+## Example Output
+
+```
+submitting: "alabama"
+counted 'a' in "alabama" -> 4, duration: 123ms
+multiplied: 4 -> 40 (src: "alabama", processing time: 234ms)
+squared: 40 -> 1600 (src: "alabama", processing time: 345ms)
+
+metrics:
+counter: processed:11, errors:0, workers:2
+multiplier: processed:6, errors:0, workers:4
+squares: processed:6, errors:0, workers:4
+```
+
+## Usage
+
+```go
+res, err := ProcessStrings(context.Background(), []string{
+    "alabama", "california", "canada", "australia",
+})
+```
+
+## Important Notes
+
+- Pools must be declared before creation to allow cross-references
+- Each stage can filter data (skip items)
+- Send can be done directly from workers
+- Close() propagates through the chain
+- Single collector simplifies result gathering
+- Batch size optimizes throughput
+- Processing time tracked through pipeline
+
+This simplified version demonstrates essential patterns for building concurrent processing pipelines while maintaining clean and efficient code structure.

--- a/exmples/direct_chain/go.mod
+++ b/exmples/direct_chain/go.mod
@@ -1,4 +1,4 @@
-module examples/chain
+module examples/direct_chain
 
 go 1.24.0
 

--- a/exmples/direct_chain/go.sum
+++ b/exmples/direct_chain/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-pkgz/pool v0.5.0 h1:fP0WpEGMAcFEBQ7l7aAZsh7RBkzx34FVgufJoVvDTYY=
+github.com/go-pkgz/pool v0.5.0/go.mod h1:e1qn5EYmXshPcOk2buL2ZC20w7RTAWUgbug+L2SyH7I=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/exmples/direct_chain/main.go
+++ b/exmples/direct_chain/main.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-pkgz/pool"
+)
+
+// data types for each stage of processing pipeline.
+// each pool transforms data from its input type to output type.
+type stringData struct {
+	idx  int       // index in the input array
+	data string    // input data
+	ts   time.Time // timestamp to track processing duration
+}
+
+type countData struct {
+	idx   int
+	count int
+	ts    time.Time
+}
+
+type multipliedData struct {
+	idx   int
+	value int
+	ts    time.Time
+}
+
+type finalData struct {
+	idx    int
+	result int
+}
+
+func ProcessStrings(ctx context.Context, input []string) ([]finalData, error) {
+	// declare pools and counters for debugging
+	var pCounter *pool.WorkerGroup[stringData]
+	var pMulti *pool.WorkerGroup[countData]
+	var pSquares *pool.WorkerGroup[multipliedData]
+	var submitted, filtered, multiplied, squared atomic.Int64
+
+	collector := pool.NewCollector[finalData](ctx, 10)
+
+	pCounter = pool.New[stringData](8, pool.WorkerFunc[stringData](func(_ context.Context, d stringData) error {
+		submitted.Add(1)
+		time.Sleep(time.Duration(rand.Intn(1)) * time.Millisecond)
+		count := strings.Count(d.data, "a")
+		if count > 2 {
+			filtered.Add(1)
+			// important: we use Send instead of Submit, because we run inside multiple workers
+			// and Submit is not thread-safe. Send does the same, just in thread-safe way
+			pMulti.Send(countData{idx: d.idx, count: count, ts: d.ts})
+		}
+		fmt.Printf("counted 'a' in %q -> %d, duration: %v\n", inputStrings[d.idx], count, time.Since(d.ts))
+		return nil
+	})).WithBatchSize(3).WithPoolCompleteFn(func(ctx context.Context) error {
+		return pMulti.Close(ctx)
+	})
+
+	pMulti = pool.New[countData](10, pool.WorkerFunc[countData](func(_ context.Context, d countData) error {
+		multiplied.Add(1)
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+		val := d.count * 10
+		fmt.Printf("multiplied: %d -> %d (src: %q, processing time: %v)\n",
+			d.count, val, inputStrings[d.idx], time.Since(d.ts))
+		pSquares.Send(multipliedData{idx: d.idx, value: val, ts: d.ts})
+		return nil
+	})).WithBatchSize(3).WithPoolCompleteFn(func(ctx context.Context) error {
+		return pSquares.Close(ctx)
+	})
+
+	pSquares = pool.New[multipliedData](10, pool.WorkerFunc[multipliedData](func(_ context.Context, d multipliedData) error {
+		squared.Add(1)
+		val := d.value * d.value
+		fmt.Printf("squared: %d -> %d (src: %q, processing time: %v)\n",
+			d.value, val, inputStrings[d.idx], time.Since(d.ts))
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+		collector.Submit(finalData{idx: d.idx, result: val})
+		return nil
+	})).WithBatchSize(3).WithPoolCompleteFn(func(ctx context.Context) error {
+		collector.Close()
+		return nil
+	})
+
+	pCounter.Go(ctx)
+	pMulti.Go(ctx)
+	pSquares.Go(ctx)
+
+	go func() {
+		for i := range input {
+			for range 100 {
+				pCounter.Submit(stringData{idx: i, data: input[i], ts: time.Now()})
+				time.Sleep(time.Duration(rand.Intn(1)) * time.Millisecond)
+			}
+		}
+		pCounter.Close(ctx)
+	}()
+
+	var results []finalData
+	for v := range collector.Iter() {
+		results = append(results, v)
+	}
+
+	// Print debug statistics
+	fmt.Printf("\nProcessing statistics:\n")
+	fmt.Printf("Total items submitted: %d\n", submitted.Load())
+	fmt.Printf("Items passed filter (>2 'a's): %d\n", filtered.Load())
+	fmt.Printf("Items multiplied: %d\n", multiplied.Load())
+	fmt.Printf("Items squared: %d\n", squared.Load())
+	fmt.Printf("Results collected: %d\n", len(results))
+
+	fmt.Printf("\nPool metrics:\ncounter: %s\nmultiplier: %s\nsquares: %s\n",
+		pCounter.Metrics().GetStats(), pMulti.Metrics().GetStats(), pSquares.Metrics().GetStats())
+	return results, nil
+}
+
+// store input array in a global for logging purposes only
+var inputStrings []string
+
+func main() {
+	inputStrings = []string{
+		"banana",
+		"alabama",
+		"california",
+		"canada",
+		"australia",
+		"alaska",
+		"arkansas",
+		"arizona",
+		"abracadabra",
+		"bandanna",
+		"barbarian",
+		"antarctica",
+		"arctic",
+		"baccarat",
+	}
+
+	res, err := ProcessStrings(context.Background(), inputStrings)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("\nFinal results:\n")
+	for i, v := range res {
+		fmt.Printf(" %d src: %q, squared a-count: %d\n", i, inputStrings[v.idx], v.result)
+	}
+	fmt.Printf("Total: %d\n", len(res))
+}

--- a/exmples/parallel_files/main.go
+++ b/exmples/parallel_files/main.go
@@ -65,7 +65,7 @@ func main() {
 	})
 
 	// set batch size and complete function
-	p = p.WithBatchSize(100).WithCompleteFn(func(_ context.Context, _ int, w pool.Worker[chunk]) error {
+	p = p.WithBatchSize(100).WithWorkerCompleteFn(func(_ context.Context, _ int, w pool.Worker[chunk]) error {
 		collector.Submit(*w.(*fileWorker))
 		return nil
 	})

--- a/exmples/tokenizer_stateful/main.go
+++ b/exmples/tokenizer_stateful/main.go
@@ -83,7 +83,7 @@ func main() {
 		}
 	}).WithBatchSize(*batchSize).
 		WithContinueOnError().
-		WithCompleteFn(func(ctx context.Context, id int, w pool.Worker[string]) error {
+		WithWorkerCompleteFn(func(ctx context.Context, id int, w pool.Worker[string]) error {
 			// type assert to get our concrete worker type
 			tw, ok := w.(*TokenizingWorker)
 			if !ok {

--- a/pool.go
+++ b/pool.go
@@ -186,8 +186,8 @@ func (p *WorkerGroup[T]) WithBatchSize(size int) *WorkerGroup[T] {
 	return p
 }
 
-// Submit adds an item to the pool for processing.
-// May block if worker channels are full.
+// Submit adds an item to the pool for processing. May block if worker channels are full.
+// Not thread-safe, intended for use by the main thread ot a single producer's thread.
 func (p *WorkerGroup[T]) Submit(v T) {
 	// check context early
 	select {
@@ -251,7 +251,7 @@ func (p *WorkerGroup[T]) Submit(v T) {
 }
 
 // Send adds an item to the pool for processing.
-// Safe for concurrent use, intended for worker-to-pool submissions.
+// Safe for concurrent use, intended for worker-to-pool submissions or for use by multiple concurrent producers.
 func (p *WorkerGroup[T]) Send(v T) {
 	p.sendMu.Lock()
 	defer p.sendMu.Unlock()


### PR DESCRIPTION
This PR addresses the issue of multiple pools communicating directly with each other. It was possible to communicate safely via `Collector`, but this is a cumbersome way and not really what the collector is for (i.e., to collect the final result in a thread-safe way).

A much simpler flow would be if one pool worker could send data to another pool directly (see examples/direct_chain). However, to make this possible, two changes are required:

1. Add the ability to submit data from multiple goroutines to a pool. The current `Submit` is not safe for such usage as it is optimized for speed, and in a typical use case, a single producer does the submissions. To address this limitation, the new `Send` method was added, which is essentially the same as `Submit` wrapped with a mutex.
2. Add a pool-level completion callback. This is needed because we have to call the pool's Close to indicate "all data sent in." We know this on the producer side, but with multiple pools, the only way to do it efficiently is to call Close of the next pool from its completion function.

Additionally, a bunch of tests and a new example for pool-to-pool chain flow have been added.